### PR TITLE
Draft: Allow functions in configs

### DIFF
--- a/apps/opentelemetry-plugins-node-tests/test/esbuild/build.ts
+++ b/apps/opentelemetry-plugins-node-tests/test/esbuild/build.ts
@@ -34,6 +34,10 @@ build({
             spanId: "spanId",
             traceFlags: "traceFlags",
           },
+          logHook: (_, record) => {
+            record["customFieldFromLogHook"] =
+              "this is a custom field added by the log hook";
+          },
         },
       }),
     }),

--- a/apps/opentelemetry-plugins-node-tests/test/plugin.test.ts
+++ b/apps/opentelemetry-plugins-node-tests/test/plugin.test.ts
@@ -160,8 +160,16 @@ function getTrace(stdOutLines: string[], spanName: string) {
         );
 
         assert.ok(requestHandlerLogMessage, "Log message handler is triggered");
-        const { traceId: pinoTraceId } = JSON.parse(requestHandlerLogMessage);
+        const { traceId: pinoTraceId, customFieldFromLogHook } = JSON.parse(
+          requestHandlerLogMessage
+        );
+
         assert.equal(traceId, pinoTraceId, "Pino logs include trace ID");
+        assert.equal(
+          customFieldFromLogHook,
+          "this is a custom field added by the log hook",
+          "The plugin allows configuring log hooks too"
+        );
       });
 
       it("redis", async () => {

--- a/apps/opentelemetry-plugins-node-tests/test/rollup/build.ts
+++ b/apps/opentelemetry-plugins-node-tests/test/rollup/build.ts
@@ -36,6 +36,10 @@ async function build() {
               spanId: "spanId",
               traceFlags: "traceFlags",
             },
+            logHook: (_, record) => {
+              record["customFieldFromLogHook"] =
+                "this is a custom field added by the log hook";
+            },
           },
         }),
       }),

--- a/apps/opentelemetry-plugins-node-tests/test/webpack/build.ts
+++ b/apps/opentelemetry-plugins-node-tests/test/webpack/build.ts
@@ -57,6 +57,10 @@ webpack(
               spanId: "spanId",
               traceFlags: "traceFlags",
             },
+            logHook: (_, record) => {
+              record["customFieldFromLogHook"] =
+                "this is a custom field added by the log hook";
+            },
           },
         }),
       }),

--- a/nx.json
+++ b/nx.json
@@ -2,7 +2,9 @@
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "targetDefaults": {
     "build": {
-      "outputs": ["{projectRoot}/dist"],
+      "outputs": [
+        "{projectRoot}/dist"
+      ],
       "cache": true
     },
     "typecheck": {
@@ -10,8 +12,13 @@
     },
     "@nx/esbuild:esbuild": {
       "cache": true,
-      "dependsOn": ["^build"],
-      "inputs": ["default", "^default"]
+      "dependsOn": [
+        "^build"
+      ],
+      "inputs": [
+        "default",
+        "^default"
+      ]
     }
   },
   "plugins": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -2174,7 +2174,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2191,7 +2190,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2208,7 +2206,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2225,7 +2222,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2242,7 +2238,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2259,7 +2254,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2276,7 +2270,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2293,7 +2286,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2310,7 +2302,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2327,7 +2318,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2344,7 +2334,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2361,7 +2350,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2378,7 +2366,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2395,7 +2382,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2412,7 +2398,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2429,7 +2414,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2446,7 +2430,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2463,7 +2446,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2480,7 +2462,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2497,7 +2478,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2514,7 +2494,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2531,7 +2510,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2548,7 +2526,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2565,7 +2542,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2582,7 +2558,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7358,9 +7333,9 @@
       "license": "MIT"
     },
     "node_modules/acorn": {
-      "version": "8.14.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
-      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
@@ -7392,7 +7367,6 @@
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
       "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "acorn": "^8.11.0"
@@ -8909,7 +8883,6 @@
       "version": "0.25.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.3.tgz",
       "integrity": "sha512-qKA6Pvai73+M2FtftpNKRxJ78GIjmFXFxd/1DVBqGo/qNhLSfv+G12n9pNoWdytJC8U00TrViOwpjT0zgqQS8Q==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -9043,9 +9016,9 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.3.0.tgz",
-      "integrity": "sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -14814,11 +14787,15 @@
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.200.0",
+        "acorn": "^8.15.0",
+        "acorn-walk": "^8.3.4",
         "semver": "^7.7.1",
         "tslib": "^2.3.0"
       },
       "devDependencies": {
-        "@types/semver": "^7.7.0"
+        "@types/semver": "^7.7.0",
+        "nyc": "^17.1.0",
+        "ts-node": "^10.9.2"
       }
     },
     "packages/opentelemetry-esbuild-plugin-node": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "nx run-many -t build",
     "clean": "nx run-many -t clean && nx reset",
     "lint": "nx run-many -t lint",
-    "test": "nx run @opentelemetry-bundler-plugins/tests:test",
+    "test": "nx run-many -t test",
     "publish": "nx release publish"
   },
   "keywords": [],

--- a/packages/opentelemetry-bundler-utils/package.json
+++ b/packages/opentelemetry-bundler-utils/package.json
@@ -12,6 +12,20 @@
   },
   "nx": {
     "targets": {
+      "test": {
+        "executor": "nx:run-commands",
+        "outputs": [
+          "{options.outputPath}"
+        ],
+        "dependsOn": [
+          "^build"
+        ],
+        "options": {
+          "cwd": "packages/opentelemetry-bundler-utils",
+          "command": "nyc node --require ts-node/register --test 'src/**/*.test.ts'",
+          "outputPath": "packages/opentelemetry-plugins-node-tests/test-dist"
+        }
+      },
       "clean": {
         "executor": "nx:run-commands",
         "options": {
@@ -31,10 +45,14 @@
   },
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.200.0",
+    "acorn": "^8.15.0",
+    "acorn-walk": "^8.3.4",
     "semver": "^7.7.1",
     "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@types/semver": "^7.7.0"
+    "@types/semver": "^7.7.0",
+    "nyc": "^17.1.0",
+    "ts-node": "^10.9.2"
   }
 }

--- a/packages/opentelemetry-bundler-utils/src/is-pure-function/index.ts
+++ b/packages/opentelemetry-bundler-utils/src/is-pure-function/index.ts
@@ -1,0 +1,1 @@
+export * from "./is-pure-function";

--- a/packages/opentelemetry-bundler-utils/src/is-pure-function/is-pure-function.test.ts
+++ b/packages/opentelemetry-bundler-utils/src/is-pure-function/is-pure-function.test.ts
@@ -1,0 +1,397 @@
+/*
+ * Copyright The Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from "assert";
+
+import { describe, it } from "node:test";
+import { isPureFunction } from "./is-pure-function";
+
+type TestCase = { code: string; isPure: boolean; description: string };
+
+describe("isPureFunction", () => {
+  (
+    [
+      // Pure no args
+      {
+        code: `function myFunc() { return 1; }`,
+        isPure: true,
+        description:
+          "Simple pure named function using `function` keyword - no args",
+      },
+      {
+        code: `function() { return 1; }`,
+        isPure: true,
+        description:
+          "Simple pure anonymous function using `function` keyword - no args",
+      },
+      {
+        code: `() => 1;`,
+        isPure: true,
+        description:
+          "Simple pure function using arrow function - no args, no new scope",
+      },
+      {
+        code: `() => { return 1; }`,
+        isPure: true,
+        description:
+          "Simple pure function using arrow function - no args, new scope",
+      },
+      {
+        code: `async function myFunc() { return 1; }`,
+        isPure: true,
+        description:
+          "Simple pure named async function using `function` keyword - no args",
+      },
+      {
+        code: `async function() { return 1; }`,
+        isPure: true,
+        description:
+          "Simple pure anonymous async function using `function` keyword - no args",
+      },
+      {
+        code: `async () => 1;`,
+        isPure: true,
+        description:
+          "Simple pure function using async arrow function - no args, no new scope",
+      },
+      {
+        code: `async () => { return 1; }`,
+        isPure: true,
+        description:
+          "Simple pure function using async arrow function - no args, new scope",
+      },
+      // Pure with args
+      {
+        code: `function myFunc(x) { return 1 + x; }`,
+        isPure: true,
+        description:
+          "Simple pure named function using `function` keyword, with args",
+      },
+      {
+        code: `function(x) { return 1 + x; }`,
+        isPure: true,
+        description:
+          "Simple pure anonymous function using `function` keyword, with args",
+      },
+      {
+        code: `(x) => 1 + x;`,
+        isPure: true,
+        description: "Simple pure function using arrow func, no new scope",
+      },
+      {
+        code: `(x) => { return 1 + x; }`,
+        isPure: true,
+        description: "Simple pure function using arrow func, new scope",
+      },
+      {
+        code: `async function myFunc(x) { return 1 + x; }`,
+        isPure: true,
+        description:
+          "Simple pure named async function using `function` keyword",
+      },
+      {
+        code: `async function(x) { return 1 + x; }`,
+        isPure: true,
+        description:
+          "Simple pure anonymous async function using `function` keyword",
+      },
+      {
+        code: `async (x) => 1 + x;`,
+        isPure: true,
+        description:
+          "Simple pure async function using arrow func, no new scope",
+      },
+      {
+        code: `async (x) => { return 1 + x; }`,
+        isPure: true,
+        description:
+          "Simple pure async function using arrow func, new scope, with args",
+      },
+      {
+        code: `async (x, y) => { await y; return 1 + x; }`,
+        isPure: true,
+        description:
+          "Simple pure async function using arrow func, new scope, with args, with await",
+      },
+      {
+        code: `
+            function myFunc(x) {
+              const y = x + 1;
+              return y;
+            }
+          `,
+        isPure: true,
+        description: "Pure function with local variable declaration",
+      },
+      // Impure no args
+      {
+        code: `function myFunc() { return 1 + x; }`,
+        isPure: false,
+        description: "Simple impure named function - function keyword, no args",
+      },
+      {
+        code: `function() { return 1 + x; }`,
+        isPure: false,
+        description:
+          "Simple impure anonymous function - function keyword, no args",
+      },
+      {
+        code: `() => { return 1 + x; }`,
+        isPure: false,
+        description:
+          "Simple impure function - arrow function, new scope, no args",
+      },
+      {
+        code: `() => 1 + x;`,
+        isPure: false,
+        description:
+          "Simple impure function - arrow function, now new scope, no args",
+      },
+      {
+        code: `async function myFunc() { return 1 + x; }`,
+        isPure: false,
+        description:
+          "Simple impure named async function - function keyword, no args",
+      },
+      {
+        code: `async function() { return 1 + x; }`,
+        isPure: false,
+        description:
+          "Simple impure anonymous async function - function keyword, no args",
+      },
+      {
+        code: `async () => { return 1 + x; }`,
+        isPure: false,
+        description: "Simple impure async function - arrow function, new scope",
+      },
+      {
+        code: `async () => 1 + x;`,
+        isPure: false,
+        description:
+          "Simple impure async function - arrow function, now new scope, no args",
+      },
+      // Impure with args
+      {
+        code: `function myFunc(x) { return 1 + y; }`,
+        isPure: false,
+        description:
+          "Simple impure named function - function keyword, with args",
+      },
+      {
+        code: `function(x) { return 1 + y; }`,
+        isPure: false,
+        description:
+          "Simple impure anonymous function - function keyword, with args",
+      },
+      {
+        code: `(x) => { return 1 + y; }`,
+        isPure: false,
+        description:
+          "Simple impure function - arrow function, new scope, with args",
+      },
+      {
+        code: `(x) => 1 + y;`,
+        isPure: false,
+        description:
+          "Simple impure function - arrow function, now new scope, with args",
+      },
+      {
+        code: `async function myFunc(x) { return 1 + y; }`,
+        isPure: false,
+        description:
+          "Simple impure named async function - function keyword, with args",
+      },
+      {
+        code: `async function(x) { return 1 + y; }`,
+        isPure: false,
+        description:
+          "Simple impure anonymous async function - function keyword, with args",
+      },
+      {
+        code: `async (x) => { return 1 + y; }`,
+        isPure: false,
+        description:
+          "Simple impure async function - arrow function, new scope, with args",
+      },
+      {
+        code: `async (x, y) => { await y; return 1 + z; }`,
+        isPure: false,
+        description:
+          "Simple impure async function - arrow function, new scope, with args, with await",
+      },
+      {
+        code: `async (x) => 1 + y;`,
+        isPure: false,
+        description:
+          "Simple impure async function - arrow function, now new scope, with args",
+      },
+      // Impure external references
+      {
+        code: `
+            function myFunc() { readFile('./file.txt', () => void 0); return 1; }
+          `,
+        isPure: false,
+        description:
+          "Impure named function with non-global reference - function keyword",
+      },
+      {
+        code: `
+              function myFunc(x) {
+              if (!x) {
+                  throw new CustomError('ahh');
+              }
+              return 1;
+              }
+          `,
+        isPure: false,
+        description:
+          "Impure named function with non global error - function keyword",
+      },
+      // Impure but with safe external references
+      {
+        code: `
+            function myFunc() { console.log('hi'); return 1; }
+            `,
+        isPure: true,
+        description: "Named function with safe reference - function keyword",
+      },
+      {
+        code: `
+          function myFunc(x) {
+              if (!x) {
+                  console.log('hi');
+              }
+              return 1;
+          }
+          `,
+        isPure: true,
+        description:
+          "Named function with safe reference in conditional branch - function keyword",
+      },
+      {
+        code: `
+          function myFunc(x) {
+              if (!x) {
+                  throw new Error('ahh');
+              }
+              return 1;
+          }
+          `,
+        isPure: true,
+        description:
+          "Named function with safe error reference - function keyword",
+      },
+      {
+        code: `
+            function myFunc(x) {
+              return Math.max(x, 10);
+            }
+          `,
+        isPure: true,
+        description: "Pure function using allowed global identifier Math",
+      },
+      {
+        code: `
+            function myFunc(x) {
+              return JSON.parse("1");
+            }
+          `,
+        isPure: true,
+        description: "Pure function using allowed global identifier JSON",
+      },
+
+      // Impure, references globals
+      {
+        code: `
+            function myFunc() {
+              const x = globalThis.x;
+              return 1 + x;
+            }
+          `,
+        isPure: false,
+        description: "References globalThis",
+      },
+      {
+        code: `
+            function myFunc() {
+              this.x = 1;
+              return 1;
+            }
+          `,
+        isPure: false,
+        description: "References this",
+      },
+      {
+        code: `
+          () => {
+            const y = this.x;
+            return 1 + y;
+          }
+        `,
+        isPure: false,
+        description: "Arrow function references this",
+      },
+      {
+        code: `
+          function myFunc() {
+            const x = navigator.x;
+            return 1 + x;
+          }
+        `,
+        isPure: false,
+        description: "References navigator",
+      },
+      {
+        code: `
+          function myFunc(x) {
+            return x + process.env.NODE_ENV;
+          }
+        `,
+        isPure: false,
+        description:
+          "Impure function referencing process.env (not in allowed identifiers)",
+      },
+      {
+        code: `
+          function myFunc(x) {
+            function inner() {
+              return y;
+            }
+            return x + inner();
+          }
+        `,
+        isPure: false,
+        description:
+          "Impure function due to closed-over variable in nested function",
+      },
+      {
+        code: `
+          function myFunc(x) {
+            return eval("x + 1");
+          }
+        `,
+        isPure: false,
+        description: "Impure function using eval",
+      },
+    ] satisfies TestCase[]
+  ).forEach(({ code, isPure, description }) => {
+    it(description, async () => {
+      const isPureResult = isPureFunction(code);
+
+      assert.equal(isPureResult, isPure, description);
+    });
+  });
+});

--- a/packages/opentelemetry-bundler-utils/src/is-pure-function/is-pure-function.ts
+++ b/packages/opentelemetry-bundler-utils/src/is-pure-function/is-pure-function.ts
@@ -1,0 +1,133 @@
+import { parse as acornParse, Program } from "acorn";
+import { full, fullAncestor } from "acorn-walk";
+import {
+  isArrowFunctionExpressionType,
+  isExpressionStatementType,
+  isFunctionExpressionType,
+  isFunctionType,
+  isIdentifierType,
+  isProgramType,
+  isThisExpressionType,
+  isVariableDeclaratorType,
+} from "./type-helpers";
+
+function parse(sourceCode: string) {
+  try {
+    return {
+      ast: acornParse(sourceCode, {
+        ecmaVersion: "latest",
+        sourceType: "module",
+      }),
+      isWrappedExpression: false,
+    };
+  } catch (err) {
+    if (
+      err instanceof SyntaxError &&
+      err.message.startsWith("Unexpected token (1:")
+    ) {
+      // An anonymous function using the function keyword (eg `function() { return 1; }`) is invalid standalone code
+      // but `(function() { return 1; })` is valid, so lets try to handle that case by wrapping the code in parens
+      return {
+        ast: acornParse(`(${sourceCode})`, {
+          ecmaVersion: "latest",
+          sourceType: "module",
+        }),
+        isWrappedExpression: true,
+      };
+    }
+    throw err;
+  }
+}
+
+function getFunctionNode(node: Program, isWrappedExpression: boolean) {
+  const candidate = node.body[0];
+  if (isWrappedExpression) {
+    if (
+      isExpressionStatementType(candidate) &&
+      isFunctionExpressionType(candidate.expression)
+    ) {
+      return candidate.expression;
+    }
+
+    return null;
+  }
+
+  if (isFunctionType(candidate)) {
+    return candidate;
+  }
+  if (
+    isExpressionStatementType(candidate) &&
+    isArrowFunctionExpressionType(candidate.expression)
+  ) {
+    return candidate.expression;
+  }
+  return null;
+}
+
+const ALLOWED_IDENIFIER_REFERENCES = new Set([
+  "console",
+  "Math",
+  "Error",
+  "AssertionError",
+  "RangeError",
+  "ReferenceError",
+  "SyntaxError",
+  "SystemError",
+  "TypeError",
+  "Date",
+  "JSON",
+  "Number",
+  "String",
+  "Boolean",
+  "parseInt",
+  "parseFloat",
+]);
+
+// TODO: Handle typescript
+export function isPureFunction(sourceCode: string): boolean {
+  let isImpure = false;
+  const { ast, isWrappedExpression } = parse(sourceCode);
+
+  fullAncestor(ast, (node) => {
+    if (!isProgramType(node)) return;
+
+    if (node.body.length !== 1) {
+      throw new Error("Node must only have one function");
+    }
+
+    const functionNode = getFunctionNode(node, isWrappedExpression);
+    if (!functionNode) return;
+
+    const localVars = new Set(
+      functionNode.params.filter((p) => isIdentifierType(p)).map((p) => p.name)
+    );
+    const usedVars = new Set<string>();
+
+    full(functionNode.body, (child) => {
+      if (isVariableDeclaratorType(child) && isIdentifierType(child.id)) {
+        localVars.add(child.id.name);
+      } else if (isIdentifierType(child)) {
+        if (!ALLOWED_IDENIFIER_REFERENCES.has(child.name)) {
+          // TODO: Configure some means of logging? env var?
+          console.warn(
+            `Function references disallowed identifier ${child.name}. Only allowed identifier references are: ${Array.from(ALLOWED_IDENIFIER_REFERENCES)}`
+          );
+          usedVars.add(child.name);
+        }
+      } else if (isThisExpressionType(child)) {
+        console.warn(
+          "Function references `this`, which is disallowed in pure functions"
+        );
+        isImpure = true;
+      }
+    });
+
+    const closedOver = Array.from(usedVars).filter((v) => !localVars.has(v));
+
+    if (closedOver.length) {
+      isImpure = true;
+    }
+  });
+
+  return !isImpure;
+}

--- a/packages/opentelemetry-bundler-utils/src/is-pure-function/type-helpers.ts
+++ b/packages/opentelemetry-bundler-utils/src/is-pure-function/type-helpers.ts
@@ -1,0 +1,55 @@
+import {
+  ArrowFunctionExpression,
+  ExpressionStatement,
+  Function,
+  Identifier,
+  Node,
+  Program,
+  VariableDeclarator,
+  FunctionExpression,
+  ThisExpression,
+} from "acorn";
+
+export function isArrowFunctionExpressionType(
+  node: Node
+): node is ArrowFunctionExpression {
+  return node.type === "ArrowFunctionExpression";
+}
+
+export function isFunctionExpressionType(
+  node: Node
+): node is FunctionExpression {
+  return node.type === "FunctionExpression";
+}
+
+export function isFunctionType(node: Node): node is Function {
+  return (
+    node.type === "FunctionDeclaration" ||
+    node.type === "FunctionExpression" ||
+    isArrowFunctionExpressionType(node)
+  );
+}
+
+export function isExpressionStatementType(
+  node: Node
+): node is ExpressionStatement {
+  return node.type === "ExpressionStatement";
+}
+
+export function isVariableDeclaratorType(
+  node: Node
+): node is VariableDeclarator {
+  return node.type === "VariableDeclarator";
+}
+
+export function isIdentifierType(node: Node): node is Identifier {
+  return node.type === "Identifier";
+}
+
+export function isProgramType(node: Node): node is Program {
+  return node.type === "Program";
+}
+
+export function isThisExpressionType(node: Node): node is ThisExpression {
+  return node.type === "ThisExpression";
+}

--- a/packages/opentelemetry-rollup-plugin-node/README.md
+++ b/packages/opentelemetry-rollup-plugin-node/README.md
@@ -94,9 +94,76 @@ process.on("SIGTERM", () => {
 
 ### Gotchas
 
-There are limitations to the configuration options for each package. Most notably, any functions are not allowed to be passed in to plugins.
+NB: Not all config options for each instrumentation will be respected. Notably, functions must be pure.
+That is not rely on closed over variables, with the exception of a few safe globals:
 
-The reason for this is that the current mechanism of instrumenting packages involves stringifying the instrumentation configs, which does not account for any external scoped dependencies, and thus creates subtle opportunities for bugs.
+- `console`
+- `Math`
+- `Error`
+- `AssertionError`
+- `RangeError`
+- `ReferenceError`
+- `SyntaxError`
+- `SystemError`
+- `TypeError`
+- `Date`
+- `JSON`
+- `Number`
+- `String`
+- `Boolean`
+- `parseInt`
+- `parseFloat`
+
+This works:
+
+```typescript
+openTelemetryPlugin({
+  instrumentations: [
+    new PinoInstrumentation({
+      logHook: (span, record) => {
+        record["resource.service.name"] =
+          provider.resource.attributes["service.name"];
+      },
+    }),
+  ],
+});
+```
+
+and so does this:
+
+```typescript
+openTelemetryPlugin({
+  instrumentations: [
+    new PinoInstrumentation({
+      logHook: (span, record) => {
+        record["resource.service.id"] = parseInt(
+          Iprovider.resource.attributes["service.id"]
+        );
+      },
+    }),
+  ],
+});
+```
+
+This would not, despite being valid javascript/typescript
+
+```typescript
+function getServiceName() {
+  return "service-name";
+}
+
+openTelemetryPlugin({
+  instrumentations: [
+    new PinoInstrumentation({
+      logHook: (span, record) => {
+        record["resource.service.name"] = getServiceName();
+      },
+    }),
+  ],
+});
+```
+
+The reason for this is that the current mechanism of instrumenting packages involves stringifying the instrumentation configs, which involves stringifying functions. Stringifying functions with closed over state is very difficult.
 
 ## Supported instrumentations
 

--- a/packages/opentelemetry-webpack-plugin-node/README.md
+++ b/packages/opentelemetry-webpack-plugin-node/README.md
@@ -110,9 +110,76 @@ process.on("SIGTERM", () => {
 
 ### Gotchas
 
-There are limitations to the configuration options for each package. Most notably, any functions are not allowed to be passed in to plugins.
+NB: Not all config options for each instrumentation will be respected. Notably, functions must be pure.
+That is not rely on closed over variables, with the exception of a few safe globals:
 
-The reason for this is that the current mechanism of instrumenting packages involves stringifying the instrumentation configs, which does not account for any external scoped dependencies, and thus creates subtle opportunities for bugs.
+- `console`
+- `Math`
+- `Error`
+- `AssertionError`
+- `RangeError`
+- `ReferenceError`
+- `SyntaxError`
+- `SystemError`
+- `TypeError`
+- `Date`
+- `JSON`
+- `Number`
+- `String`
+- `Boolean`
+- `parseInt`
+- `parseFloat`
+
+This works:
+
+```typescript
+openTelemetryPlugin({
+  instrumentations: [
+    new PinoInstrumentation({
+      logHook: (span, record) => {
+        record["resource.service.name"] =
+          provider.resource.attributes["service.name"];
+      },
+    }),
+  ],
+});
+```
+
+and so does this:
+
+```typescript
+openTelemetryPlugin({
+  instrumentations: [
+    new PinoInstrumentation({
+      logHook: (span, record) => {
+        record["resource.service.id"] = parseInt(
+          Iprovider.resource.attributes["service.id"]
+        );
+      },
+    }),
+  ],
+});
+```
+
+This would not, despite being valid javascript/typescript
+
+```typescript
+function getServiceName() {
+  return "service-name";
+}
+
+openTelemetryPlugin({
+  instrumentations: [
+    new PinoInstrumentation({
+      logHook: (span, record) => {
+        record["resource.service.name"] = getServiceName();
+      },
+    }),
+  ],
+});
+```
+
+The reason for this is that the current mechanism of instrumenting packages involves stringifying the instrumentation configs, which involves stringifying functions. Stringifying functions with closed over state is very difficult.
 
 ## Supported instrumentations
 


### PR DESCRIPTION
As a compliment to https://github.com/DrewCorlin/opentelemetry-node-bundler-plugins/issues/6, let's validate that the function being passed in is pure.

Will wait until https://github.com/DrewCorlin/opentelemetry-node-bundler-plugins/issues/6 is merged to merge this as there will be conflicts, and the `javascript-stringify` approach is almost certainly more robust than the approach to stringifying functions here