### PR TITLE
feat: use `rolldown-string` for sourcemap generation

### DIFF
--- a/apps/opentelemetry-plugins-node-tests/test/esbuild/build.ts
+++ b/apps/opentelemetry-plugins-node-tests/test/esbuild/build.ts
@@ -24,6 +24,7 @@ build({
   entryPoints: [path.join(import.meta.dirname, "../test-app/app.ts")],
   bundle: true,
   outfile: "test-dist/esbuild/app.cjs",
+  sourcemap: true,
   target: "node20",
   platform: "node",
   plugins: [

--- a/apps/opentelemetry-plugins-node-tests/test/plugin.test.ts
+++ b/apps/opentelemetry-plugins-node-tests/test/plugin.test.ts
@@ -91,7 +91,7 @@ function getTrace(stdOutLines: string[], spanName: string) {
   {
     scriptFile: "build.ts",
     bundler: "esbuild",
-    distFiles: ["app.cjs"],
+    distFiles: ["app.cjs", "app.cjs.map"],
   },
   {
     scriptFile: "build.cjs",
@@ -101,22 +101,22 @@ function getTrace(stdOutLines: string[], spanName: string) {
   {
     scriptFile: "build.ts",
     bundler: "webpack",
-    distFiles: ["app.cjs", "app.cjs.LICENSE.txt"],
+    distFiles: ["app.cjs", "app.cjs.map", "app.cjs.LICENSE.txt"],
   },
   {
     scriptFile: "build.ts",
     bundler: "rollup",
-    distFiles: ["app.cjs"],
+    distFiles: ["app.cjs", "app.cjs.map"],
   },
   {
     scriptFile: "build.ts",
     bundler: "unplugin-rollup",
-    distFiles: ["app.cjs"],
+    distFiles: ["app.cjs", "app.cjs.map"],
   },
   {
     scriptFile: "build.ts",
     bundler: "unplugin-rolldown",
-    distFiles: ["app.cjs"],
+    distFiles: ["app.cjs", "app.cjs.map"],
   },
 ].forEach(({ scriptFile, bundler, distFiles }) => {
   describe(

--- a/apps/opentelemetry-plugins-node-tests/test/rollup/build.ts
+++ b/apps/opentelemetry-plugins-node-tests/test/rollup/build.ts
@@ -15,10 +15,9 @@
  */
 
 import { rollup } from "rollup";
-// eslint-disable-next-line @nx/enforce-module-boundaries
 import { openTelemetryPlugin } from "opentelemetry-rollup-plugin-node";
 import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentations-node";
-import path from "path";
+import { fileURLToPath } from "url";
 import typescript from "@rollup/plugin-typescript";
 import commonjs from "@rollup/plugin-commonjs";
 import nodeResolve from "@rollup/plugin-node-resolve";
@@ -26,7 +25,7 @@ import json from "@rollup/plugin-json";
 
 async function build() {
   const bundle = await rollup({
-    input: path.join(import.meta.dirname, "../test-app/app.ts"),
+    input: fileURLToPath(new URL("../test-app/app.ts", import.meta.url)),
     plugins: [
       nodeResolve({ extensions: [".mjs", ".js", ".json", ".ts"] }),
       openTelemetryPlugin({
@@ -48,15 +47,16 @@ async function build() {
       commonjs(),
       json(),
       typescript({
-        tsconfig: path.join(import.meta.dirname, "../../tsconfig.json"),
-        sourceMap: false,
+        tsconfig: fileURLToPath(new URL("../../tsconfig.json", import.meta.url)),
+        sourceMap: true,
       }),
     ],
   });
 
   await bundle.write({
-    file: path.join(import.meta.dirname, "../../test-dist/rollup/app.cjs"),
+    file: fileURLToPath(new URL("../../test-dist/rollup/app.cjs", import.meta.url)),
     format: "cjs",
+    sourcemap: true,
   });
 
   await bundle.close();

--- a/apps/opentelemetry-plugins-node-tests/test/rollup/build.ts
+++ b/apps/opentelemetry-plugins-node-tests/test/rollup/build.ts
@@ -17,7 +17,7 @@
 import { rollup } from "rollup";
 import { openTelemetryPlugin } from "opentelemetry-rollup-plugin-node";
 import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentations-node";
-import { fileURLToPath } from "url";
+import path from "path";
 import typescript from "@rollup/plugin-typescript";
 import commonjs from "@rollup/plugin-commonjs";
 import nodeResolve from "@rollup/plugin-node-resolve";
@@ -25,7 +25,7 @@ import json from "@rollup/plugin-json";
 
 async function build() {
   const bundle = await rollup({
-    input: fileURLToPath(new URL("../test-app/app.ts", import.meta.url)),
+    input: path.join(import.meta.dirname, "../test-app/app.ts"),
     plugins: [
       nodeResolve({ extensions: [".mjs", ".js", ".json", ".ts"] }),
       openTelemetryPlugin({
@@ -47,14 +47,14 @@ async function build() {
       commonjs(),
       json(),
       typescript({
-        tsconfig: fileURLToPath(new URL("../../tsconfig.json", import.meta.url)),
+        tsconfig: path.join(import.meta.dirname, "../../tsconfig.json"),
         sourceMap: true,
       }),
     ],
   });
 
   await bundle.write({
-    file: fileURLToPath(new URL("../../test-dist/rollup/app.cjs", import.meta.url)),
+    file: path.join(import.meta.dirname, "../../test-dist/rollup/app.cjs"),
     format: "cjs",
     sourcemap: true,
   });

--- a/apps/opentelemetry-plugins-node-tests/test/unplugin-rolldown/build.ts
+++ b/apps/opentelemetry-plugins-node-tests/test/unplugin-rolldown/build.ts
@@ -50,6 +50,7 @@ async function build() {
       "../../test-dist/unplugin-rolldown/app.cjs",
     ),
     format: "cjs",
+    sourcemap: true,
   });
 
   await bundle.close();

--- a/apps/opentelemetry-plugins-node-tests/test/unplugin-rollup/build.ts
+++ b/apps/opentelemetry-plugins-node-tests/test/unplugin-rollup/build.ts
@@ -17,7 +17,7 @@
 import { rollup } from "rollup";
 import { openTelemetryPlugin } from "opentelemetry-unplugin-node";
 import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentations-node";
-import { fileURLToPath } from "url";
+import path from "path";
 import typescript from "@rollup/plugin-typescript";
 import commonjs from "@rollup/plugin-commonjs";
 import nodeResolve from "@rollup/plugin-node-resolve";
@@ -25,7 +25,7 @@ import json from "@rollup/plugin-json";
 
 async function build() {
   const bundle = await rollup({
-    input: fileURLToPath(new URL("../test-app/app.ts", import.meta.url)),
+    input: path.join(import.meta.dirname, "../test-app/app.ts"),
     plugins: [
       nodeResolve({ extensions: [".mjs", ".js", ".json", ".ts"] }),
       openTelemetryPlugin.rollup({
@@ -47,16 +47,14 @@ async function build() {
       commonjs(),
       json(),
       typescript({
-        tsconfig: fileURLToPath(new URL("../../tsconfig.json", import.meta.url)),
+        tsconfig: path.join(import.meta.dirname, "../../tsconfig.json"),
         sourceMap: true,
       }),
     ],
   });
 
   await bundle.write({
-    file: fileURLToPath(
-      new URL("../../test-dist/unplugin-rollup/app.cjs", import.meta.url)
-    ),
+    file: path.join(import.meta.dirname, "../../test-dist/unplugin-rollup/app.cjs"),
     format: "cjs",
     sourcemap: true,
   });

--- a/apps/opentelemetry-plugins-node-tests/test/unplugin-rollup/build.ts
+++ b/apps/opentelemetry-plugins-node-tests/test/unplugin-rollup/build.ts
@@ -15,10 +15,9 @@
  */
 
 import { rollup } from "rollup";
-// eslint-disable-next-line @nx/enforce-module-boundaries
 import { openTelemetryPlugin } from "opentelemetry-unplugin-node";
 import { getNodeAutoInstrumentations } from "@opentelemetry/auto-instrumentations-node";
-import path from "path";
+import { fileURLToPath } from "url";
 import typescript from "@rollup/plugin-typescript";
 import commonjs from "@rollup/plugin-commonjs";
 import nodeResolve from "@rollup/plugin-node-resolve";
@@ -26,7 +25,7 @@ import json from "@rollup/plugin-json";
 
 async function build() {
   const bundle = await rollup({
-    input: path.join(import.meta.dirname, "../test-app/app.ts"),
+    input: fileURLToPath(new URL("../test-app/app.ts", import.meta.url)),
     plugins: [
       nodeResolve({ extensions: [".mjs", ".js", ".json", ".ts"] }),
       openTelemetryPlugin.rollup({
@@ -48,18 +47,18 @@ async function build() {
       commonjs(),
       json(),
       typescript({
-        tsconfig: path.join(import.meta.dirname, "../../tsconfig.json"),
-        sourceMap: false,
+        tsconfig: fileURLToPath(new URL("../../tsconfig.json", import.meta.url)),
+        sourceMap: true,
       }),
     ],
   });
 
   await bundle.write({
-    file: path.join(
-      import.meta.dirname,
-      "../../test-dist/unplugin-rollup/app.cjs",
+    file: fileURLToPath(
+      new URL("../../test-dist/unplugin-rollup/app.cjs", import.meta.url)
     ),
     format: "cjs",
+    sourcemap: true,
   });
 
   await bundle.close();

--- a/apps/opentelemetry-plugins-node-tests/test/webpack/build.ts
+++ b/apps/opentelemetry-plugins-node-tests/test/webpack/build.ts
@@ -1,4 +1,4 @@
-import { fileURLToPath } from "url";
+import path from "path";
 import { OpenTelemetryWebpackPlugin } from "opentelemetry-webpack-plugin-node";
 
 import webpack from "webpack";
@@ -10,9 +10,9 @@ webpack(
     target: "node",
     mode: "production",
     devtool: "source-map",
-    entry: fileURLToPath(new URL("../test-app/app.ts", import.meta.url)),
+    entry: path.join(import.meta.dirname, "../test-app/app.ts"),
     output: {
-      path: fileURLToPath(new URL("../../test-dist/webpack", import.meta.url)),
+      path: path.join(import.meta.dirname, "../../test-dist/webpack"),
       filename: "app.cjs",
     },
     optimization: {

--- a/apps/opentelemetry-plugins-node-tests/test/webpack/build.ts
+++ b/apps/opentelemetry-plugins-node-tests/test/webpack/build.ts
@@ -1,5 +1,4 @@
-import path from "path";
-// eslint-disable-next-line @nx/enforce-module-boundaries
+import { fileURLToPath } from "url";
 import { OpenTelemetryWebpackPlugin } from "opentelemetry-webpack-plugin-node";
 
 import webpack from "webpack";
@@ -10,9 +9,10 @@ webpack(
   {
     target: "node",
     mode: "production",
-    entry: path.join(import.meta.dirname, "../test-app/app.ts"),
+    devtool: "source-map",
+    entry: fileURLToPath(new URL("../test-app/app.ts", import.meta.url)),
     output: {
-      path: path.join(import.meta.dirname, "../../test-dist/webpack"),
+      path: fileURLToPath(new URL("../../test-dist/webpack", import.meta.url)),
       filename: "app.cjs",
     },
     optimization: {
@@ -34,7 +34,7 @@ webpack(
           use: {
             loader: "ts-loader",
             options: {
-              configFile: path.join(import.meta.dirname, "../../tsconfig.webpack.json")
+              transpileOnly: true,
             },
           },
           exclude: /node_modules/,

--- a/package-lock.json
+++ b/package-lock.json
@@ -3400,9 +3400,9 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
@@ -5786,7 +5786,7 @@
       "version": "0.137.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.137.0.tgz",
       "integrity": "sha512-WT+Gb24i8hmvo85AIv2oEYouEXkRlKAlT9WaCa3TfLgNCN+GhrJOGZuIlMouAh38Qe4QOx26eUOVsq70qXrywA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
@@ -6256,7 +6256,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@rollup/plugin-commonjs": {
@@ -12234,13 +12234,12 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.17",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
-      "dev": true,
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/make-dir": {
@@ -13936,7 +13935,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.2.tgz",
       "integrity": "sha512-x0CrQQqCXWGeI8dTvFfN/Dnv3yMKT9hv5jFjlOreKAx9wqLq9wz7VvLLHyaAXC90/CpggTu9SisSbsJJTPSjNQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -14077,6 +14076,29 @@
       },
       "engines": {
         "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/rolldown-string": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/rolldown-string/-/rolldown-string-0.3.0.tgz",
+      "integrity": "sha512-qGhBPNSv/27uzFBQdO+Cs4YAXC/1PKznD7Jz5Fl7NIAIlteuTPBTBWBhCpJ2AFTqLsoKvvUr7wSjqSUip0Fkpg==",
+      "license": "MIT",
+      "dependencies": {
+        "magic-string": "^0.30.21"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sxzz"
+      },
+      "peerDependencies": {
+        "rolldown": "*"
+      },
+      "peerDependenciesMeta": {
+        "rolldown": {
+          "optional": true
+        }
       }
     },
     "node_modules/rollup": {
@@ -16311,6 +16333,7 @@
       "dependencies": {
         "@opentelemetry/instrumentation": "^0.200.0",
         "javascript-stringify": "^2.1.0",
+        "rolldown-string": "^0.3.0",
         "semver": "^7.7.1"
       },
       "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -284,6 +284,7 @@
       "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -2162,6 +2163,32 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.6.3.tgz",
@@ -2178,6 +2205,7 @@
       "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.2",
         "tslib": "^2.4.0"
@@ -2189,6 +2217,7 @@
       "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -4253,6 +4282,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "0.2.4",
         "@yarnpkg/lockfile": "^1.1.0",
@@ -4340,6 +4370,7 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -4439,6 +4470,7 @@
       "integrity": "sha512-SLX36allrcnVaPYG3R78F/UZZsBsvbc7lMCLx37LyH5MJ1KAAZ2E3mW9OAD3zGz0G8q/BtoS5VUrjzDydhD6LQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -5876,6 +5908,7 @@
       "integrity": "sha512-aR0uffYI700OEEH4gYnitAnv3vzVGXCFvYfdpu/CJKvk4pHfLPEy/JSZyrpQ+15WhXe1yJRXLtfQ84s4mEXnPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2",
         "generic-pool": "3.9.0",
@@ -6660,6 +6693,7 @@
       "integrity": "sha512-BBjg0QNuEEmJSoU/++JOXhrjWdu3PTyYeJWsvchsI0Aqtj8ICkz/DqlwtXbmZVZ5vuDPpTfFlwDBZe81zgShMA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@swc-node/core": "^1.13.1",
         "@swc-node/sourcemap-support": "^0.5.0",
@@ -6706,6 +6740,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.8"
@@ -6921,6 +6956,7 @@
       "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -6931,9 +6967,42 @@
       "integrity": "sha512-2YEtj5HJVbKivud9N4bpPBAyZhj4S2Ipe5LkUG94alTpr7in/GU/EARgPAd3BwU+YOmFVJC2+kjqhGRi3r0ZpQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3"
       }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.9.0",
@@ -7118,6 +7187,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
       "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -7271,6 +7341,7 @@
       "integrity": "sha512-67kYYShjBR0jNI5vsf/c3WG4u+zDnCTHTPqVMQguffaWWFs7artgwKmfwdifl+r6XyM5LYLas/dInj2T0SgJyw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.31.0",
         "@typescript-eslint/types": "8.31.0",
@@ -7695,6 +7766,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7719,6 +7791,20 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/address": {
@@ -7912,6 +7998,14 @@
       "integrity": "sha512-Xg+9RwCg/0p32teKdGMPTPnVXKD0w3DfHnFTficozsAgsvq2XenPJq/MYpzzQ/v8zrOyJn6Ds39VA4JIDwFfqw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -8457,6 +8551,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -8941,6 +9036,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -9363,6 +9466,7 @@
       "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -9426,6 +9530,7 @@
       "integrity": "sha512-E6Mtz9oGQWDCpV12319d59n4tx9zOTXSTmc8BLVxBx+G/0RdM5MvEEJLU9c0+aleoePYYgVTOsRblx433qmhWQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9487,6 +9592,7 @@
       "integrity": "sha512-Epgp/EofAUeEpIdZkW60MHKvPyru1ruQJxPL+WIycnaPApuseK0Zpkrh/FwL9oIpQvIhJwV7ptOy0DWUjTlCiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -12153,6 +12259,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
     "node_modules/makeerror": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.12.tgz",
@@ -12572,6 +12686,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@napi-rs/wasm-runtime": "0.2.4",
         "@yarnpkg/lockfile": "^1.1.0",
@@ -13823,6 +13938,7 @@
       "integrity": "sha512-x0CrQQqCXWGeI8dTvFfN/Dnv3yMKT9hv5jFjlOreKAx9wqLq9wz7VvLLHyaAXC90/CpggTu9SisSbsJJTPSjNQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.137.0",
         "@rolldown/pluginutils": "^1.0.0"
@@ -14100,6 +14216,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -14274,6 +14391,7 @@
       "integrity": "sha512-D3YaD0aRxR3mEcqnidIs7ReYJFVzWdd6fXJYUM8ixcQcJRGTka/b3saV0KflYhyVJXKhb947GndU35SxYNResQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
@@ -14852,6 +14970,62 @@
         "node": ">= 8"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
@@ -14968,7 +15142,8 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tsx": {
       "version": "4.22.4",
@@ -15525,6 +15700,7 @@
       "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15707,6 +15883,14 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
@@ -15777,6 +15961,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.99.7.tgz",
       "integrity": "sha512-CNqKBRMQjwcmKR0idID5va1qlhrqVUKpovi+Ec79ksW8ux7iS1+A6VqzfZXgVYCFRKl7XL5ap3ZoMpwBJxcg0w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.6",
@@ -15825,6 +16010,7 @@
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",
@@ -16092,6 +16278,17 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/packages/opentelemetry-bundler-utils/package.json
+++ b/packages/opentelemetry-bundler-utils/package.json
@@ -56,6 +56,7 @@
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.200.0",
     "javascript-stringify": "^2.1.0",
+    "rolldown-string": "^0.3.0",
     "semver": "^7.7.1"
   },
   "devDependencies": {

--- a/packages/opentelemetry-bundler-utils/src/wrap-module.ts
+++ b/packages/opentelemetry-bundler-utils/src/wrap-module.ts
@@ -14,8 +14,13 @@
  * limitations under the License.
  */
 
+import type { CodeTransform as RolldownStringTransform } from "rolldown-string";
+import { generateTransform, rolldownString } from "rolldown-string";
+
+export type CodeTransform = RolldownStringTransform;
+
 interface ModuleParams {
-  path?: string;
+  path: string;
   oTelInstrumentationPackage: string;
   oTelInstrumentationClass: string;
   oTelInstrumentationConstructorArgs?: string;
@@ -33,10 +38,11 @@ export function wrapModule(
     instrumentationName,
     oTelInstrumentationConstructorArgs = "",
   }: ModuleParams
-): string {
-  return `
-(function() {
-  ${originalSource}
+): CodeTransform {
+  const s = rolldownString(originalSource, path);
+
+  s.prepend("(function() {\n");
+  s.append(`
 })(...arguments);
 {
   const { diag } = require('@opentelemetry/api');
@@ -76,5 +82,11 @@ export function wrapModule(
     diag.error('Error applying instrumentation ${instrumentationName}', e);
   }
 }
-`;
+`);
+
+  const result = generateTransform(s, path, true);
+  if (!result) {
+    throw new Error(`Failed to generate wrapped module transform for ${path}`);
+  }
+  return result;
 }

--- a/packages/opentelemetry-bundler-utils/tsdown.config.ts
+++ b/packages/opentelemetry-bundler-utils/tsdown.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
   platform: "node",
   attw: true,
   deps: {
-    skipNodeModulesBundle: true,
+    alwaysBundle: ["rolldown-string"],
+    onlyBundle: false,
   },
 });

--- a/packages/opentelemetry-esbuild-plugin-node/src/plugin.ts
+++ b/packages/opentelemetry-esbuild-plugin-node/src/plugin.ts
@@ -27,6 +27,7 @@ import {
   getOtelPackageToInstrumentationConfig,
   getPackageConfig,
   isBuiltIn,
+  CodeTransform,
   OpenTelemetryPluginParams,
   shouldIgnoreModule,
   wrapModule,
@@ -121,22 +122,35 @@ export function openTelemetryPlugin(
           });
           const extractedModule = pluginData.extractedModule;
 
+          const result = wrapModule(contents.toString(), {
+            path: join(extractedModule.package, extractedModule.path),
+            moduleVersion: pluginData.moduleVersion,
+            instrumentationName: pluginData.instrumentationName,
+            oTelInstrumentationClass: config.oTelInstrumentationClass,
+            oTelInstrumentationPackage: config.oTelInstrumentationPackage,
+            oTelInstrumentationConstructorArgs:
+              config.configGenerator(packageConfig),
+          });
+
           return {
-            contents: wrapModule(contents.toString(), {
-              path: join(extractedModule.package, extractedModule.path),
-              moduleVersion: pluginData.moduleVersion,
-              instrumentationName: pluginData.instrumentationName,
-              oTelInstrumentationClass: config.oTelInstrumentationClass,
-              oTelInstrumentationPackage: config.oTelInstrumentationPackage,
-              oTelInstrumentationConstructorArgs:
-                config.configGenerator(packageConfig),
-            }),
+            contents: toEsbuildContents(result),
             resolveDir: dirname(path),
           };
         }
       );
     },
   };
+}
+
+function toEsbuildContents({ code, map }: CodeTransform): string {
+  if (!map) return code;
+
+  // esbuild's onLoad result has no separate source map field. It consumes
+  // plugin-generated maps through an inline sourceMappingURL in contents.
+  // example: https://esbuild.github.io/plugins/#svelte-plugin
+  const sourceMap = typeof map === "string" ? map : map.toString();
+  const encodedMap = Buffer.from(sourceMap).toString("base64");
+  return `${code}\n//# sourceMappingURL=data:application/json;base64,${encodedMap}`;
 }
 
 const moduleVersionByPackageJsonPath = new Map<string, string>();

--- a/packages/opentelemetry-webpack-plugin-node/src/plugin.ts
+++ b/packages/opentelemetry-webpack-plugin-node/src/plugin.ts
@@ -42,7 +42,7 @@ if (!require.cache[tempLoaderPath]) {
           oTelInstrumentationConstructorArgs
         } = this.getOptions();
 
-        return wrapModule(originalSource, {
+        const result = wrapModule(originalSource, {
           path,
           moduleVersion,
           instrumentationName,
@@ -50,6 +50,7 @@ if (!require.cache[tempLoaderPath]) {
           oTelInstrumentationPackage,
           oTelInstrumentationConstructorArgs
         });
+        this.callback(null, result.code, result.map);
       };
     `
   );


### PR DESCRIPTION
Stacked on #19, which is a necessary prerequisite for using `rolldown-string`, which publishes as ESM-only.

This switches the manual code modification step with a step that uses `rolldown-string`, which is a wrapper over `magic-string` with a fast path if rolldown is used. See the docs here: https://npmx.dev/package/rolldown-string. By using this, we get accurate source maps after the plugin's patching occurs. 